### PR TITLE
poetry init; add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__
+/.idea
+/venv/
+*.egg-info
+/build/
+/dist/
+.env
+# setup.py # actually, commit the stub setup.py file so that users can pip3 install -e .
+.hypothesis/
+/poetry.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "jaxtorch"
+version = "0.1.0"
+description = "PyTorch-style interface for JAX"
+authors = ["nshepperd <nshepperd@gmail.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+einops = "^0.3.0"
+cbor2 = "^5.4.1"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup
+
+packages = \
+['jaxtorch', 'jaxtorch.nn']
+
+package_data = \
+{'': ['*']}
+
+install_requires = \
+['cbor2>=5.4.1,<6.0.0', 'einops>=0.3.0,<0.4.0']
+
+setup_kwargs = {
+    'name': 'jaxtorch',
+    'version': '0.1.0',
+    'description': 'PyTorch-style interface for JAX',
+    'long_description': None,
+    'author': 'nshepperd',
+    'author_email': 'nshepperd@gmail.com',
+    'maintainer': None,
+    'maintainer_email': None,
+    'url': None,
+    'packages': packages,
+    'package_data': package_data,
+    'install_requires': install_requires,
+    'python_requires': '>=3.7,<4.0',
+}
+
+
+setup(**setup_kwargs)


### PR DESCRIPTION
This PR lets you publish to pypi via poetry.

I use a `poetry-bump` script for this:

```bash
#!/bin/bash

set -ex

poetry version "$@"
version="$(poetry version -s)"

# write new setup.py file
poetry build --format sdist
tar -xvf dist/*-${version}.tar.gz -O '*/setup.py' > setup.py

git add .
git commit -m "Version ${version}"
git tag "${version}"
git push
git push --tags
poetry build
poetry publish
```

Then I just run `poetry-bump patch`.